### PR TITLE
解决Got packet 1156包乱序的错误

### DIFF
--- a/src/main/java/io/cdm/net/AbstractConnection.java
+++ b/src/main/java/io/cdm/net/AbstractConnection.java
@@ -506,13 +506,14 @@ public abstract class AbstractConnection implements NIOConnection {
 	public void close(String reason) {
 		if (!isClosed.get()) {
 			closeSocket();
-			isClosed.set(true);
 			if (processor != null) {
 				processor.removeConnection(this);
 			}
 			this.cleanup();
 			isSupportCompress = false;
 
+			//修改Got packet 1156包乱序的错误
+			isClosed.set(true);
 			// ignore null information
 			if (Strings.isNullOrEmpty(reason)) {
 				return;


### PR DESCRIPTION
1.通过日志打印发现buffer重复申请，使用mat工具分析内存 发现有多个线程持有了同一个buffer
可能进行了重复回收导致buffer重复申请
2.修改连接是否为closed状态 必须要等到释放所持有的buffer才可以设置问题是isClosed的标志位
3.cleanup里面清理了buffer 然后定时任务frontendCheck里面也是更具isClosed清理了buffer导致重复回收